### PR TITLE
issue #3 golint - 'p' before comment and package

### DIFF
--- a/hello/goroutine.go
+++ b/hello/goroutine.go
@@ -1,4 +1,4 @@
-p /**
+/**
  * Filename: goroutine.go
  * Author: Nyah Check
  * Usage: Experiments on Goroutines. Adding Mutex's to guarantee channeling
@@ -8,14 +8,13 @@ package main
 
 import (
 	"fmt"
-	"time"
 	"sync"
+	"time"
 )
 
 var (
 	counter = 0
-	lock sync.Mutex
-
+	lock    sync.Mutex
 )
 
 func main() {


### PR DESCRIPTION
Hi, this pull requests fixes the 'p' before your comment and package main :)
no the linter find to error in hello/goroutine.go.
gofmt is also fixed for this file, hope this is fine :)